### PR TITLE
Add basic web UI

### DIFF
--- a/web/router.go
+++ b/web/router.go
@@ -9,6 +9,14 @@ import (
 func SetupRouter() *gin.Engine {
 	router := gin.Default()
 
+	// 加载模板和静态资源
+	router.LoadHTMLGlob("web/templates/*")
+	router.Static("/static", "web/static")
+
+	router.GET("/", func(c *gin.Context) {
+		c.HTML(200, "index.html", nil)
+	})
+
 	// 定义API路由
 	api := router.Group("/api")
 	{

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -1,0 +1,43 @@
+// Simple JavaScript to handle form submissions and call API endpoints
+
+document.getElementById('loginForm').addEventListener('submit', async function(e) {
+    e.preventDefault();
+    const data = {
+        account: document.getElementById('loginAccount').value,
+        password: document.getElementById('loginPassword').value,
+        school_id: document.getElementById('loginSchool').value
+    };
+    const resp = await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data)
+    });
+    const res = await resp.json();
+    document.getElementById('loginResult').textContent = res.message || res.error;
+});
+
+document.getElementById('queryForm').addEventListener('submit', async function(e) {
+    e.preventDefault();
+    const account = document.getElementById('queryAccount').value;
+    const resp = await fetch('/api/query?account=' + encodeURIComponent(account));
+    const res = await resp.json();
+    document.getElementById('queryResult').textContent = JSON.stringify(res, null, 2);
+});
+
+document.getElementById('signForm').addEventListener('submit', async function(e) {
+    e.preventDefault();
+    const data = {
+        account: document.getElementById('signAccount').value,
+        address: document.getElementById('signAddress').value,
+        address_name: document.getElementById('signAddressName').value,
+        latitude: document.getElementById('signLatitude').value,
+        longitude: document.getElementById('signLongitude').value
+    };
+    const resp = await fetch('/api/sign', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data)
+    });
+    const res = await resp.json();
+    document.getElementById('signResult').textContent = res.message || res.error;
+});

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>习讯云签到工具</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container py-4">
+    <h1 class="mb-4 text-center">习讯云签到工具 Web UI</h1>
+    <div class="row">
+        <div class="col-md-4">
+            <h3>登录</h3>
+            <form id="loginForm">
+                <div class="mb-3">
+                    <label class="form-label">账号</label>
+                    <input type="text" class="form-control" id="loginAccount" required>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">密码</label>
+                    <input type="password" class="form-control" id="loginPassword" required>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">学校ID</label>
+                    <input type="text" class="form-control" id="loginSchool" required>
+                </div>
+                <button type="submit" class="btn btn-primary">登录</button>
+            </form>
+            <div id="loginResult" class="mt-2"></div>
+        </div>
+        <div class="col-md-4">
+            <h3>查询</h3>
+            <form id="queryForm">
+                <div class="mb-3">
+                    <label class="form-label">账号</label>
+                    <input type="text" class="form-control" id="queryAccount" required>
+                </div>
+                <button type="submit" class="btn btn-primary">查询</button>
+            </form>
+            <pre id="queryResult" class="mt-2"></pre>
+        </div>
+        <div class="col-md-4">
+            <h3>签到</h3>
+            <form id="signForm">
+                <div class="mb-3">
+                    <label class="form-label">账号</label>
+                    <input type="text" class="form-control" id="signAccount" required>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">地址</label>
+                    <input type="text" class="form-control" id="signAddress" required>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">地址名称</label>
+                    <input type="text" class="form-control" id="signAddressName">
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">纬度</label>
+                    <input type="text" class="form-control" id="signLatitude">
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">经度</label>
+                    <input type="text" class="form-control" id="signLongitude">
+                </div>
+                <button type="submit" class="btn btn-primary">签到</button>
+            </form>
+            <div id="signResult" class="mt-2"></div>
+        </div>
+    </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="/static/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an `index.html` template using Bootstrap for login/query/sign actions
- add `app.js` to handle form submissions via fetch calls
- serve templates and static files from Gin router

## Testing
- `go vet ./...` *(fails: terminated)*
- `go test ./...` *(fails: terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68400343c098832c8ee6d130a5eea8cf